### PR TITLE
Updated and added orion_argument_spec, to Fix KeyError: 'port' in orion_query module

### DIFF
--- a/plugins/modules/orion_query.py
+++ b/plugins/modules/orion_query.py
@@ -83,7 +83,7 @@ results:
 import requests
 import csv
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.solarwinds.orion.plugins.module_utils.orion import OrionModule
+from ansible_collections.solarwinds.orion.plugins.module_utils.orion import OrionModule, orion_argument_spec
 
 try:
     import orionsdk
@@ -107,10 +107,8 @@ def write_to_csv(nodes, csv_file_path):
 
 
 def main():
-    argument_spec = dict(
-        hostname=dict(required=True),
-        username=dict(required=True, no_log=True),
-        password=dict(required=True, no_log=True),
+    argument_spec = orion_argument_spec
+    argument_spec.update(
         query=dict(required=True, type=str),
         csv_path=dict(required=False, type=str),
     )


### PR DESCRIPTION
Please validate what I did looks right, but this change fixed the below error I was getting with orion_query module with the updated collection 2.0.0 /orionsdk0.4.0/solarwinds 2024.2.0

```
TASK [Run a node query in Orion.Nodes] **************************************************
Thursday 27 June 2024  13:57:30 +0000 (0:00:00.023)       0:00:00.023 ********* 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'port'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/andrewba/.ansible/tmp/ansible-tmp-1719496651.0973973-63604-40421410856746/AnsiballZ_orion_query.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/andrewba/.ansible/tmp/ansible-tmp-1719496651.0973973-63604-40421410856746/AnsiballZ_orion_query.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/andrewba/.ansible/tmp/ansible-tmp-1719496651.0973973-63604-40421410856746/AnsiballZ_orion_query.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.solarwinds.orion.plugins.modules.orion_query', init_globals=dict(_module_fqn='ansible_collections.solarwinds.orion.plugins.modules.orion_query', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_solarwinds.orion.orion_query_payload_v7oz0ikv/ansible_solarwinds.orion.orion_query_payload.zip/ansible_collections/solarwinds/orion/plugins/modules/orion_query.py\", line 135, in <module>\n  File \"/tmp/ansible_solarwinds.orion.orion_query_payload_v7oz0ikv/ansible_solarwinds.orion.orion_query_payload.zip/ansible_collections/solarwinds/orion/plugins/modules/orion_query.py\", line 125, in main\n  File \"/tmp/ansible_solarwinds.orion.orion_query_payload_v7oz0ikv/ansible_solarwinds.orion.orion_query_payload.zip/ansible_collections/solarwinds/orion/plugins/module_utils/orion.py\", line 51, in __init__\nKeyError: 'port'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

 