### PR TITLE
Inventory Plugin - changed orion_verify to verify

### DIFF
--- a/plugins/inventory/orion_nodes_inventory.py
+++ b/plugins/inventory/orion_nodes_inventory.py
@@ -231,7 +231,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                     'username': self.get_option('orion_username'),
                     'password': orion_password,
                     'port': self.get_option('orion_port'),
-                    'verify': self.get_option('orion_verify'),
+                    'verify': self.get_option('verify'),
                 }
             __SWIS__ = SwisClient(**swis_options)
             __SWIS__.query('SELECT uri FROM Orion.Environment')


### PR DESCRIPTION
I was testing the inventory plugin again and was getting this error:

```
[WARNING]:  * Failed to parse /home/admin/inventory/hosts_orion.yml with auto
plugin: Failed to connect to Orion database:   'Requested entry (plugin_type: inventory plugin:
ansible_collections.solarwinds.orion.plugins.inventory.orion_nodes_inventory setting: orion_verify
) was not defined in configuration.'
```

When I change "orion_verify" to "verify" it worked.