### PR TITLE
Fix idempotency for boolean custom properties

### DIFF
--- a/plugins/modules/orion_custom_property.py
+++ b/plugins/modules/orion_custom_property.py
@@ -120,7 +120,7 @@ def main():
     if module.params['state'] == 'present':
         try:
             prop_name, prop_value = orion.get_node_custom_property_value(node, module.params['property_name'])
-            if prop_value != module.params['property_value']:
+            if str(prop_value) != str(module.params['property_value']):
                 if not module.check_mode:
                     orion.add_custom_property(node, module.params['property_name'], module.params['property_value'])
                 changed = True


### PR DESCRIPTION
## Summary
- `orion_custom_property` reports `changed` on every run when the SolarWinds custom property type is boolean
- Root cause: the SWIS API returns Python `bool` (`True`/`False`) for boolean properties, but `module.params['property_value']` is always `str` (defined as `type='str'` in the argspec). The comparison `bool != str` is always `True`, so the module writes on every run.
- Fix: wrap both sides in `str()` so `str(True) == str("True")` evaluates correctly and the module only writes when the value actually differs.

## Test plan
- [x] Create a boolean custom property in SolarWinds (e.g. `Internet_Facing`)
- [x] Run a playbook that sets it via `orion_custom_property` with `property_value: "True"` — reports `changed`
- [x] Run the same playbook again — currently reports `changed` (bug), should report `ok` with fix
- [x] Verified with text-type custom property that existing behavior is unaffected (`str("sometext") == str("sometext")`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>