### PR TITLE
Fix dead code and check_mode bug in orion_node_ncm

### DIFF
--- a/changelogs/fragments/fix-orion-node-ncm-dead-code-and-check-mode.yml
+++ b/changelogs/fragments/fix-orion-node-ncm-dead-code-and-check-mode.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - orion_node_ncm module - Fix check_mode returning changed=False when node would be added to NCM.
+  - orion_node_ncm module - Remove unreachable dead code after premature exit_json when adding node to NCM.

--- a/plugins/modules/orion_node_ncm.py
+++ b/plugins/modules/orion_node_ncm.py
@@ -139,7 +139,7 @@ def main():
             else:
                 # if the node is not already in NCM, add the node and update the connection profile
                 if module.check_mode:
-                    module.exit_json(changed=False, orion_node=node)
+                    module.exit_json(changed=True, orion_node=node)
                 else:
                     # add the node to NCM
                     orion.add_node_to_ncm(node)
@@ -147,12 +147,8 @@ def main():
                     ncm_node = orion.get_ncm_node(node)
                     profile_dict = index_connection_profiles(orion)
                     # update the connection profile
-                    was_changed = orion.update_ncm_node_connection_profile(profile_dict, module.params['profile_name'], ncm_node)
+                    orion.update_ncm_node_connection_profile(profile_dict, module.params['profile_name'], ncm_node)
                     module.exit_json(changed=True, orion_node=node)
-                    if was_changed:
-                        module.exit_json(changed=True, orion_node=node)
-                    else:
-                        module.exit_json(changed=False, orion_node=node)
         except Exception as OrionException:
             module.fail_json(msg='Failed to add or update node in NCM: {0}'.format(OrionException))
 


### PR DESCRIPTION
## Bugfixes

- **check_mode returned wrong value**: When a node is not already in NCM and `check_mode` is active, the module returned `changed=False`. Since the operation would add the node to NCM, it should return `changed=True`.
- **Unreachable dead code**: A premature `module.exit_json(changed=True)` on line 151 made the subsequent `was_changed` conditional block (lines 152-155) unreachable. Removed the duplicate exit and dead code.

Includes changelog fragment.