### PR TITLE
Fix error message typos in orion_node module

### DIFF
--- a/changelogs/fragments/fix-orion-node-error-message-typos.yml
+++ b/changelogs/fragments/fix-orion-node-error-message-typos.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - orion_node module - Fix unmute_node error message that incorrectly said "Error muting node" instead of "Error unmuting node".
+  - orion_node module - Fix typo in credential validation error message ("Failed validate credentails" to "Failed to validate credentials").

--- a/plugins/modules/orion_node.py
+++ b/plugins/modules/orion_node.py
@@ -397,7 +397,7 @@ def add_node(module, orion):
             snmp_validation_passed = False
             snmp_validation_error = 'SNMP validation exception: {0}'.format(str(OrionException))
             if module.params['validate_snmp_required']:
-                module.fail_json(msg='Failed validate credentails for node: {0}'.format(str(OrionException)))
+                module.fail_json(msg='Failed to validate credentials for node: {0}'.format(str(OrionException)))
     # Add Node
     try:
         __SWIS__.create('Orion.Nodes', **props)
@@ -512,7 +512,7 @@ def unmute_node(module, node):
     try:
         __SWIS__.invoke('Orion.AlertSuppression', 'ResumeAlerts', [node['uri']])
     except Exception as OrionException:
-        module.fail_json(msg='Error muting node: {0}'.format(str(OrionException)))
+        module.fail_json(msg='Error unmuting node: {0}'.format(str(OrionException)))
 
 
 def main():


### PR DESCRIPTION
## Bugfixes

- `unmute_node()` error message said "Error muting node" instead of "Error unmuting node"
- Credential validation error message said "Failed validate credentails" instead of "Failed to validate credentials"

Includes changelog fragment.