### PR TITLE
Fix orion_query crash when writing CSV with empty results

### DIFF
--- a/changelogs/fragments/fix-orion-query-empty-csv-crash.yml
+++ b/changelogs/fragments/fix-orion-query-empty-csv-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - orion_query module - Fix crash when writing CSV with empty query results. swis_query returns None for empty results which caused a TypeError in write_to_csv.

--- a/plugins/modules/orion_query.py
+++ b/plugins/modules/orion_query.py
@@ -120,6 +120,8 @@ def main():
     orion = OrionModule(module)
 
     results = orion.swis_query(module.params['query'])
+    if results is None:
+        results = []
     if module.params['csv_path']:
         write_to_csv(results, module.params['csv_path'])
 


### PR DESCRIPTION
## Bugfix

When a SWQL query returns no results, `swis_query()` returns `None`. If `csv_path` is set, `write_to_csv(None, ...)` crashes with `TypeError: 'NoneType' object is not subscriptable`.

The fix defaults empty results to an empty list before passing to `write_to_csv()`. The function already handles empty lists correctly (produces a CSV with headers only).

Includes changelog fragment.