### PR TITLE
Fix except Exception blocks losing original error context

### DIFF
--- a/changelogs/fragments/fix-except-exception-raise-exception.yml
+++ b/changelogs/fragments/fix-except-exception-raise-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - multiple modules - Fix ``except Exception`` blocks that re-raised a bare ``Exception()`` without the original message or traceback. Changed to bare ``raise`` to preserve the original exception context.

--- a/plugins/inventory/orion_nodes_inventory.py
+++ b/plugins/inventory/orion_nodes_inventory.py
@@ -131,7 +131,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 try:
     import orionsdk

--- a/plugins/module_utils/orion.py
+++ b/plugins/module_utils/orion.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     HAS_DATEUTIL = False
 except Exception:
-    raise Exception
+    raise
 
 try:
     import orionsdk
@@ -35,7 +35,7 @@ try:
 except ImportError:
     HAS_ORION = False
 except Exception:
-    raise Exception
+    raise
 
 
 def orion_argument_spec():

--- a/plugins/modules/orion_credential_set.py
+++ b/plugins/modules/orion_credential_set.py
@@ -194,7 +194,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_custom_property.py
+++ b/plugins/modules/orion_custom_property.py
@@ -91,7 +91,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_ncm_config.py
+++ b/plugins/modules/orion_ncm_config.py
@@ -162,7 +162,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def get_config_history(orion, node, limit=5):

--- a/plugins/modules/orion_node.py
+++ b/plugins/modules/orion_node.py
@@ -290,7 +290,7 @@ try:
 except ImportError:
     HAS_DATETIME = False
 except Exception:
-    raise Exception
+    raise
 try:
     import requests
     HAS_REQUESTS = True
@@ -298,7 +298,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def add_credential_set(node, credential_set_name, credential_set_type):

--- a/plugins/modules/orion_node_application.py
+++ b/plugins/modules/orion_node_application.py
@@ -96,7 +96,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_node_custom_poller.py
+++ b/plugins/modules/orion_node_custom_poller.py
@@ -84,7 +84,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_node_hardware_health.py
+++ b/plugins/modules/orion_node_hardware_health.py
@@ -105,7 +105,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 # Mapping of polling method names to their corresponding IDs

--- a/plugins/modules/orion_node_info.py
+++ b/plugins/modules/orion_node_info.py
@@ -66,7 +66,7 @@ try:
 except ImportError:
     HAS_DATEUTIL = False
 except Exception:
-    raise Exception
+    raise
 try:
     import requests
     HAS_REQUESTS = True
@@ -74,7 +74,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_node_interface.py
+++ b/plugins/modules/orion_node_interface.py
@@ -157,7 +157,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_node_interface_info.py
+++ b/plugins/modules/orion_node_interface_info.py
@@ -93,7 +93,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_node_ncm.py
+++ b/plugins/modules/orion_node_ncm.py
@@ -83,7 +83,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def index_connection_profiles(orion_module):

--- a/plugins/modules/orion_node_poller.py
+++ b/plugins/modules/orion_node_poller.py
@@ -115,7 +115,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_node_poller_info.py
+++ b/plugins/modules/orion_node_poller_info.py
@@ -95,7 +95,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_query.py
+++ b/plugins/modules/orion_query.py
@@ -90,7 +90,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def write_to_csv(nodes, csv_file_path):

--- a/plugins/modules/orion_update_node.py
+++ b/plugins/modules/orion_update_node.py
@@ -90,7 +90,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_volume.py
+++ b/plugins/modules/orion_volume.py
@@ -140,7 +140,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():

--- a/plugins/modules/orion_volume_info.py
+++ b/plugins/modules/orion_volume_info.py
@@ -97,7 +97,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 except Exception:
-    raise Exception
+    raise
 
 
 def main():


### PR DESCRIPTION
## Bugfix

All import `try/except` blocks across the collection used this pattern:

```python
except Exception:
    raise Exception
```

This re-raises a **new** bare `Exception()` with no message, losing the original exception's message, type, and traceback. Changed to bare `raise` to preserve the original exception context:

```python
except Exception:
    raise
```

**19 files affected** across `plugins/modules/`, `plugins/module_utils/`, and `plugins/inventory/`.

Includes changelog fragment.