### PR TITLE
Fix duplicate assertion in orion_node_ncm integration test

### DIFF
--- a/changelogs/fragments/fix-ncm-test-duplicate-assert.yml
+++ b/changelogs/fragments/fix-ncm-test-duplicate-assert.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - orion_node_ncm integration test - Fix duplicate assertion that checked update_ncm_01.changed twice instead of also checking update_ncm_02.changed.

--- a/tests/integration/targets/orion_node_ncm/tasks/ncm.yml
+++ b/tests/integration/targets/orion_node_ncm/tasks/ncm.yml
@@ -57,7 +57,7 @@
       - not add_ncm_04.changed
       - add_ncm_02.orion_node is defined
       - update_ncm_01.changed
-      - update_ncm_01.changed
+      - update_ncm_02.changed
 
 - name: Remove node from NCM (check)
   orion_node_ncm: &remove_ncm


### PR DESCRIPTION
## Bugfix

The NCM profile update assertion checked `update_ncm_01.changed` twice instead of also checking `update_ncm_02.changed`. The actual update result was never validated.

```yaml
# Before (line 59-60):
- update_ncm_01.changed
- update_ncm_01.changed  # duplicate

# After:
- update_ncm_01.changed
- update_ncm_02.changed  # correct
```

Includes changelog fragment.