### PR TITLE
Fix credential set test asserting wrong return key

### DIFF
--- a/changelogs/fragments/fix-credential-set-test-wrong-return-key.yml
+++ b/changelogs/fragments/fix-credential-set-test-wrong-return-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - orion_credential_set integration test - Fix assertion checking wrong return key ``credentials`` (plural) instead of ``credential`` (singular) to match module return value.

--- a/tests/integration/targets/orion_credential_set/tasks/assign.yml
+++ b/tests/integration/targets/orion_credential_set/tasks/assign.yml
@@ -52,7 +52,7 @@
       - assign_snmpv3_01.changed
       - assign_snmpv3_02.changed
       - assign_snmpv3_02.orion_node is defined
-      - assign_snmpv3_02.credentials is defined
+      - assign_snmpv3_02.credential is defined
       - not assign_snmpv3_03.changed
       - not assign_snmpv3_04.changed
 


### PR DESCRIPTION
## Bugfix

The assign integration test asserted `assign_snmpv3_02.credentials` (plural) but the `orion_credential_set` module returns `credential` (singular) — see RETURN documentation and `module.exit_json(changed=changed, credential=credential_set, orion_node=node)` at line 276.

This assertion would always fail when run against a live SolarWinds instance.

Includes changelog fragment.