### PR TITLE
Fix typo in orion_node_hardware_health error message

### DIFF
--- a/changelogs/fragments/fix-hardware-health-typo.yml
+++ b/changelogs/fragments/fix-hardware-health-typo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - orion_node_hardware_health module - Fix typo in error message "montior" to "monitor".

--- a/plugins/modules/orion_node_hardware_health.py
+++ b/plugins/modules/orion_node_hardware_health.py
@@ -162,7 +162,7 @@ def main():
                     orion.swis.invoke('Orion.HardwareHealth.HardwareInfoBase', 'EnableHardwareHealth', node['netobjectid'], polling_method_id)
                 changed = True
             elif hh_poller[0]['PollingMethod'] != polling_method_id:
-                module.fail_json(msg="HardwareHealth montior exists, but does not match provided polling_method parameter.")
+                module.fail_json(msg="HardwareHealth monitor exists, but does not match provided polling_method parameter.")
         elif module.params['state'] == 'absent':
             if hh_poller:
                 if not module.check_mode:


### PR DESCRIPTION
## Bugfix

Typo in error message: "HardwareHealth montior exists" → "HardwareHealth monitor exists"

Includes changelog fragment.