### PR TITLE
Fix orion_ncm_config ImportConfig argument order

### DIFF
--- a/changelogs/fragments/orion_ncm_config_importconfig_args.yml
+++ b/changelogs/fragments/orion_ncm_config_importconfig_args.yml
@@ -5,7 +5,7 @@ bugfixes:
     comments, configText), so imports were archiving the literal string
     'manual-import' as the config body, filing the real configuration into
     the Comments field, and titling every entry with the config_type value.
-minor_changes:
+major_changes:
   - orion_ncm_config - add ``config_title`` (defaults to
     ``<node caption>-<YYYY-MM-DD_HHMMSS>``) and ``comments`` options for the
     import method, and document that NCM stamps imported entries with config

--- a/changelogs/fragments/orion_ncm_config_importconfig_args.yml
+++ b/changelogs/fragments/orion_ncm_config_importconfig_args.yml
@@ -1,0 +1,12 @@
+---
+bugfixes:
+  - orion_ncm_config - fix the positional argument order passed to the NCM
+    ImportConfig verb. The verb's parameters are (nodeId, configTitle,
+    comments, configText), so imports were archiving the literal string
+    'manual-import' as the config body, filing the real configuration into
+    the Comments field, and titling every entry with the config_type value.
+minor_changes:
+  - orion_ncm_config - add ``config_title`` (defaults to
+    ``<node caption>-<YYYY-MM-DD_HHMMSS>``) and ``comments`` options for the
+    import method, and document that NCM stamps imported entries with config
+    type 'Imported' regardless of ``config_type``.

--- a/plugins/modules/orion_ncm_config.py
+++ b/plugins/modules/orion_ncm_config.py
@@ -28,12 +28,32 @@ options:
         type: str
     config_type:
         description:
-            - The type of configuration being imported or downloaded.
+            - The type of configuration being downloaded or uploaded.
             - Common values include 'Running', 'Startup', 'Manual', etc.
             - For device-specific types, consult your NCM documentation.
+            - Not used by C(import), which always records the entry with
+              config type 'Imported'.
         required: false
         type: str
         default: 'Manual'
+    config_title:
+        description:
+            - Title for the imported config archive entry, shown as the
+              entry's name in the NCM config list.
+            - Only used by C(import).
+            - Defaults to the node caption followed by a timestamp,
+              C(<caption>-<YYYY-MM-DD_HHMMSS>).
+        required: false
+        type: str
+        version_added: "3.2.0"
+    comments:
+        description:
+            - Comments stored on the imported config archive entry.
+            - Only used by C(import).
+        required: false
+        type: str
+        default: 'Imported via Ansible API'
+        version_added: "3.2.0"
     method:
         description:
             - Method to use for configuration operations.
@@ -62,18 +82,17 @@ EXAMPLES = r'''
     password: "{{ solarwinds_pass }}"
     name: "{{ node_name }}"
     config_content: "{{ device_config_backup_content }}"
-    config_type: "Running"
+    config_title: "{{ node_name }}-daily-backup"
     method: import
   delegate_to: localhost
 
-- name: Import router configuration from file
+- name: Import router configuration from file, titled <caption>-<timestamp>
   jeisenbath.solarwinds.orion_ncm_config:
     hostname: "{{ solarwinds_server }}"
     username: "{{ solarwinds_user }}"
     password: "{{ solarwinds_pass }}"
     ip_address: "192.168.1.100"
     config_content: "{{ lookup('file', '/path/to/device_config.txt') }}"
-    config_type: "Running"
   delegate_to: localhost
 
 - name: Upload configuration to device via NCM
@@ -128,9 +147,8 @@ ncm_result:
         "method": "ImportConfig",
         "parameters_used": {
             "node_id": "12345678-abcd-ef01-2345-6789abcdef01",
-            "config_type": "Cisco",
-            "title": "daily-backup",
-            "comments": "Daily configuration backup import",
+            "title": "CORE-SW-01-2025-08-28_131627",
+            "comments": "Imported via Ansible API",
             "config_length": 2048
         }
     }
@@ -150,6 +168,8 @@ config_history:
         }
     ]
 '''
+
+import datetime
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.jeisenbath.solarwinds.plugins.module_utils.orion import OrionModule, orion_argument_spec
@@ -219,6 +239,8 @@ def main():
     argument_spec.update(
         config_content=dict(required=False, type='str', no_log=False),
         config_type=dict(required=False, type='str', default='Manual'),
+        config_title=dict(required=False, type='str'),
+        comments=dict(required=False, type='str', default='Imported via Ansible API'),
         method=dict(required=False, choices=['import', 'upload', 'download'], default='import'),
     )
 
@@ -283,20 +305,23 @@ def main():
                 # Normalize NCM NodeID to proper GUID format
                 normalized_node_id = normalize_ncm_node_id(ncm_node_id)
 
-                # Prepare parameters exactly like the working Python example
-                config_type_str = str(config_type) if config_type else "Running"
                 config_text = str(config_content)
-                title = "manual-import"
-                comments = "Imported via Ansible API"
+                title = module.params['config_title']
+                if not title:
+                    title = f"{node['caption']}-{datetime.datetime.now().strftime('%Y-%m-%d_%H%M%S')}"
+                comments = str(module.params['comments'])
 
-                # Call ImportConfig with the exact parameter order from working example
+                # ImportConfig positional parameters are (nodeId, configTitle,
+                # comments, configText): the title becomes the entry's display
+                # name in the NCM config list, and NCM stamps the entry's
+                # ConfigType as 'Imported' itself, so config_type plays no
+                # part in imports.
                 result = orion.swis.invoke(
                     'Cirrus.ConfigArchive', 'ImportConfig',
                     normalized_node_id,
-                    config_type_str,
-                    config_text,
                     title,
-                    comments)
+                    comments,
+                    config_text)
 
                 import_result = {
                     'success': True,
@@ -305,7 +330,6 @@ def main():
                     'method': 'ImportConfig',
                     'parameters_used': {
                         'node_id': normalized_node_id,
-                        'config_type': config_type_str,
                         'title': title,
                         'comments': comments,
                         'config_length': len(config_text)

--- a/tests/integration/targets/orion_ncm_config/tasks/import.yml
+++ b/tests/integration/targets/orion_ncm_config/tasks/import.yml
@@ -25,6 +25,18 @@
   delegate_to: localhost
   register: import_02
 
+- name: Import config with explicit config_title and comments
+  orion_ncm_config:
+    hostname: "{{ orion_test_solarwinds_server }}"
+    username: "{{ orion_test_solarwinds_username }}"
+    password: "{{ orion_test_solarwinds_password }}"
+    name: "{{ orion_test_node_name }}"
+    method: import
+    config_content: "{{ orion_test_config_content }}"
+    config_title: ansible-test explicit title
+    comments: ansible-test explicit comments
+  delegate_to: localhost
+  register: import_03
 
 - name: Import asserts
   ansible.builtin.assert:
@@ -35,3 +47,41 @@
       - import_02.ncm_result.node_id is defined
       - import_02.ncm_result.success == true
       - import_02.config_history is defined
+      # config_title defaults to <node caption>-<timestamp>, comments to the
+      # documented default value
+      - import_02.ncm_result.parameters_used.title.startswith(orion_test_node_name)
+      - import_02.ncm_result.parameters_used.comments == 'Imported via Ansible API'
+      - import_03.changed
+      - import_03.ncm_result.success == true
+      - import_03.ncm_result.parameters_used.title == 'ansible-test explicit title'
+      - import_03.ncm_result.parameters_used.comments == 'ansible-test explicit comments'
+
+# Read the explicit-title entry back from the archive to verify the ImportConfig
+# argument order end to end: config_title is the entry's display name in the NCM
+# config list, comments landed in Comments, the archived body is the imported
+# configuration text, and NCM stamps imported entries with config type
+# 'Imported' regardless of config_type.
+- name: Read imported entry back from the NCM config archive
+  orion_query:
+    hostname: "{{ orion_test_solarwinds_server }}"
+    username: "{{ orion_test_solarwinds_username }}"
+    password: "{{ orion_test_solarwinds_password }}"
+    query: >-
+      SELECT ConfigTitle, Comments, Config, ConfigType
+      FROM Cirrus.ConfigArchive
+      WHERE NodeID = '{{ import_03.ncm_result.parameters_used.node_id }}'
+      AND ConfigTitle = 'ansible-test explicit title'
+  delegate_to: localhost
+  register: import_04
+  until: import_04.results | length > 0
+  retries: 6
+  delay: 5
+
+- name: Archive entry asserts
+  ansible.builtin.assert:
+    that:
+      - import_04.results | length == 1
+      - import_04.results[0].ConfigTitle == 'ansible-test explicit title'
+      - import_04.results[0].Comments == 'ansible-test explicit comments'
+      - import_04.results[0].ConfigType == 'Imported'
+      - orion_test_config_content | trim in import_04.results[0].Config


### PR DESCRIPTION
## Summary

`orion_ncm_config` with `method: import` passes its arguments to the `Cirrus.ConfigArchive.ImportConfig` verb in the wrong positional order, so every import files a corrupted archive entry:

- the entry's **Config Title** (its display name in the NCM config list) gets the `config_type` value (e.g. "Running"),
- the archived **Config body is the literal 13-character string `manual-import`** (the module's hardcoded title),
- the **real device configuration lands in the Comments field**.

The verb's actual positional signature is `(nodeId, configTitle, comments, configText)`. I verified this empirically against a live NCM instance (SolarWinds Platform 2024.x) by invoking `ImportConfig` over SWIS with a distinct marker string in every slot and reading the archive entry back via SWQL:

| position | marker | landed in |
|---|---|---|
| 2 | `PROBE-POS2` | `ConfigTitle` |
| 3 | `PROBE-POS3` | `Comments` |
| 4 | `PROBE-POS4` | `Config` (the archived body) |
| 5 | `PROBE-POS5` | nowhere (accepted but ignored) |

A 4-argument call returns HTTP 200, so the fix drops the 5th argument. NCM stamps imported entries with ConfigType `Imported` itself regardless of what is passed, so `config_type` plays no part in imports at all.

## Changes

- Call `ImportConfig` with the correct order: `(nodeId, title, comments, configText)`.
- New `config_title` option (import only) — the entry's display name; defaults to `<node caption>-<YYYY-MM-DD_HHMMSS>` so imports are identifiable in the config list, matching how the NCM UI titles manual imports by filename.
- New `comments` option (import only), default `Imported via Ansible API` (previously hardcoded).
- Documentation: note that `config_type` is not used by `import`, update examples and the `ncm_result` sample, add a changelog fragment.

Both new options carry `version_added: 3.2.0` since `orion_ncm_config` itself is still unreleased at 3.2.0.

## Testing

Ran an end-to-end backup playbook (device config → `orion_ncm_config` import) against live SolarWinds/NCM with this fix inside an execution environment build:

- archive entry titled `obm-01-2026-07-28_124158` (default title path),
- `LENGTH(Config)` = 386,922 — the full device configuration is the archived body,
- `Comments` = "Imported via Ansible API",
- explicit `config_title` also verified,
- `ansible-doc jeisenbath.solarwinds.orion_ncm_config` parses the updated docs cleanly,
- backward compatible: existing playbooks that pass only `config_content`/`config_type` keep working (their imports simply become correct, titled by the new default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
